### PR TITLE
fixed nullpointer exception when finding no bam file for detected sample

### DIFF
--- a/src/de/dkfz/b080/co/common/WorkflowUsingMergedBams.groovy
+++ b/src/de/dkfz/b080/co/common/WorkflowUsingMergedBams.groovy
@@ -104,7 +104,7 @@ abstract class WorkflowUsingMergedBams extends Workflow {
             // Check the cache for the dataset. If not, try to load the files.
             if (!foundBamFilesForDatasets.containsKey(dataSet)) {
 
-                runtimeService.metadataAccessor.getAllBamFiles(context).collect { BasicBamFile bam ->
+                runtimeService.metadataAccessor.getAllBamFiles(context).findAll().collect { BasicBamFile bam ->
                     Sample sample = bam.sample
                     if (sample.getType() == Sample.SampleType.CONTROL)
                         bamsControlMerged << bam


### PR DESCRIPTION
following bam-related files exist for sample tumor - but no real bam file exists. However, sample 'tumor' is detected and no corresponding bam file is found. Leads to nullpointer exception.

alignment_backup/tumor_$PID_merged.mdup.bam.bamlook.sh  alignment_backup/tumor_$PID_merged.mdup.bam_fp  alignment_backup/tumor_$PID_merged.mdup.bam_fp1000
